### PR TITLE
Fix off-by-one null-delimiter in password

### DIFF
--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -82,14 +82,11 @@ void dns_server_stop()
             socket_fd = -1;
         }
         /* Wait for recvfrom() to return, signified by the mutex being
-         * released */
+         * released; task will then automatically stop after that */
         if (socket_in_use_mutex != NULL)
         {
-            xSemaphoreTake(socket_in_use_mutex, pdMS_TO_TICKS(500));
+            assert(xSemaphoreTake(socket_in_use_mutex, pdMS_TO_TICKS(500)));
         }
-        /* Now it is safe to delete the task */
-        vTaskDelete(task_dns_server);
-        task_dns_server = NULL;
         if (socket_in_use_mutex != NULL)
         {
             vSemaphoreDelete(socket_in_use_mutex);
@@ -158,7 +155,7 @@ void dns_server(void *pvParameters)
         xSemaphoreTake(socket_in_use_mutex, portMAX_DELAY);
         length = recvfrom(socket_fd, data, sizeof(data), 0, (struct sockaddr *)&client, &client_len); /* read udp request */
         xSemaphoreGive(socket_in_use_mutex);
-        
+
         if (length <= 0)
         {
             /* Socket was closed or error occurred, exit the loop */

--- a/src/wifi_manager.c
+++ b/src/wifi_manager.c
@@ -227,7 +227,7 @@ void decelerate_retry_timer(void) {
 
 /**
  * @brief Helper function to safely start the retry timer with the current period
- * 
+ *
  * This function updates the timer period and starts it. It should only be called
  * from the WiFi manager task context, not from timer callbacks.
  */
@@ -1407,6 +1407,8 @@ void wifi_manager_set_callback(message_code_t message_code,
 
   if (cb_ptr_arr && message_code < WM_MESSAGE_CODE_COUNT) {
     cb_ptr_arr[message_code] = func_ptr;
+  } else {
+    ESP_LOGE(TAG, "Failed to create callback %d", message_code);
   }
 }
 

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -259,8 +259,8 @@ extern "C"
 
 	typedef struct ap_config_t
 	{
-		char ssid[32];
-		char password[64];
+		char ssid[MAX_SSID_SIZE+1];
+		char password[MAX_PASSWORD_SIZE+1];
 	} ap_config_t;
 
 	/**


### PR DESCRIPTION
Fix for:

```
/home/user/ProjectsPrivate/<redacted>/firmware/managed_components/esp32-wifi-manager/src/wifi_manager.c:2454:33: error: array subscript 64 is above array bounds of 'char[64]' [-Werror=array-bounds=]
 2454 |       saved_networks[i].password[MAX_PASSWORD_SIZE] =
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
In file included from /home/user/ProjectsPrivate/<redacted>/firmware/managed_components/esp32-wifi-manager/src/wifi_manager.c:60:
/home/user/ProjectsPrivate/<redacted>/firmware/managed_components/esp32-wifi-manager/src/wifi_manager.h:263:22: note: while referencing 'password'
  263 |                 char password[64];
      |                      ^~~~~~~~
cc1: some warnings being treated as errors
```